### PR TITLE
Fix path to Whisper model

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,21 @@
 from fastapi import FastAPI, WebSocket
 from faster_whisper import WhisperModel
-import asyncio, struct
+import asyncio
+import os
 import numpy as np
 
 app = FastAPI()
 
 # Use the snapshot directory containing model files
-model = WhisperModel("../shared_models/models--Systran--faster-whisper-tiny/snapshots/d90ca5fe260221311c53c58e660288d3deb8d356", device="cpu")
+MODEL_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "shared_models",
+    "models--Systran--faster-whisper-tiny",
+    "snapshots",
+    "d90ca5fe260221311c53c58e660288d3deb8d356",
+)
+model = WhisperModel(MODEL_DIR, device="cpu")
 
 @app.get("/")
 async def root():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ uvicorn==0.34.3
 uvloop==0.21.0
 watchfiles==1.1.0
 websockets==15.0.1
+faster-whisper==1.1.1


### PR DESCRIPTION
## Summary
- fix relative path bug in backend by computing absolute model path
- include faster-whisper in backend requirements

## Testing
- `python3 -m py_compile backend/main.py`
- `uvicorn backend.main:app --port 8000 --no-access-log`

------
https://chatgpt.com/codex/tasks/task_e_685577f254f8832dab2e0a643a6fd823